### PR TITLE
Fix 25 flake8 F403 and F405 issues

### DIFF
--- a/toolkit/scripts/crowbar/lib/main.py
+++ b/toolkit/scripts/crowbar/lib/main.py
@@ -9,7 +9,7 @@ import tempfile
 
 try:
     import paramiko
-    from lib.core.common import *
+    from lib.core.common import bcolors
     from lib.core.exceptions import CrowbarExceptions
     from lib.core.iprange import IpRange
     from lib.core.logger import Logger


### PR DESCRIPTION
```
1     F403 'from lib.core.common import *' used; unable to detect undefined names
24    F405 'bcolors' may be undefined, or defined from star imports: lib.core.common
```